### PR TITLE
search: fix for default app-rdm queries

### DIFF
--- a/invenio_records_global_search/services/services.py
+++ b/invenio_records_global_search/services/services.py
@@ -1,18 +1,24 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023-2024 Graz University of Technology.
+# Copyright (C) 2023-2025 Graz University of Technology.
 #
 # invenio-records-global-search is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
 # details.
 
 """Global Search Services."""
+from typing import Any
 
+from flask import current_app
 from flask_principal import Identity
 from invenio_pidstore.errors import PIDDoesNotExistError
 from invenio_records_resources.services import RecordService
-from invenio_records_resources.services.records.results import RecordItem
+from invenio_records_resources.services.records.results import RecordItem, RecordList
 from invenio_records_resources.services.uow import UnitOfWork, unit_of_work
+
+from invenio_records_global_search.services.utils import (
+    replace_query_params_with_known_schema,
+)
 
 
 class GlobalSearchRecordService(RecordService):
@@ -42,3 +48,55 @@ class GlobalSearchRecordService(RecordService):
         except PIDDoesNotExistError:
             self.record_cls.gs_pid = gs_pid
             return self._create(self.record_cls, identity, data, uow=uow, expand=expand)
+
+    def search(
+        self,
+        identity: Identity,
+        params: dict | None = None,
+        search_preference: str | None = None,
+        expand: bool = False,  # noqa: FBT001, FBT002
+        **kwargs: Any,  # noqa: ANN401
+    ) -> RecordList:
+        """Search for records matching the querystring.
+
+        Method was overriden to rework query params that come as default from invenio-app-rdm
+        into the global-search schema structure.
+        """
+        try:
+            schema = self.config.schema
+            metadata_field = schema().fields.get("metadata")
+            metadata_schema = metadata_field.nested
+        except AttributeError:
+            current_app.logger("WARN: Schema unknown for query pre-processing")
+            return super().search(
+                identity,
+                params=params,
+                search_preference=search_preference,
+                expand=expand,
+                **kwargs,
+            )
+
+        if "q" not in params:
+            return super().search(
+                identity,
+                params=params,
+                search_preference=search_preference,
+                expand=expand,
+                **kwargs,
+            )
+
+        for metadata_field_name in metadata_schema().fields:
+            if metadata_field_name in params["q"]:
+                full_q = params["q"]
+                params["q"] = replace_query_params_with_known_schema(
+                    full_q,
+                    metadata_field_name,
+                )
+
+        return super().search(
+            identity,
+            params=params,
+            search_preference=search_preference,
+            expand=expand,
+            **kwargs,
+        )

--- a/invenio_records_global_search/services/utils.py
+++ b/invenio_records_global_search/services/utils.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2025 Graz University of Technology.
+#
+# invenio-records-global-search is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+"""Utils class."""
+
+import re
+
+
+def replace_query_params_with_known_schema(full_q: str, known_field_name: str) -> str:
+    """Replace query fields.
+
+    Given a default invenio-app-rdm query, replace the queried fields with fields from
+    package defined schema.
+    """
+    result_q = full_q
+    pattern = re.compile(r"\bmetadata(?:\.\w+)*(?=[^a-zA-Z0-9_-])")
+    matches = re.findall(pattern, full_q)
+    for match in matches:
+        result_q = result_q.replace(match, f"metadata.{known_field_name}")
+
+    return result_q

--- a/tests/utilstests.py
+++ b/tests/utilstests.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2025 Graz University of Technology.
+#
+# invenio-records-global-search is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Utils tests."""
+
+import pytest
+
+from invenio_records_global_search.services.utils import (
+    replace_query_params_with_known_schema,
+)
+
+
+@pytest.mark.parametrize(
+    ("full_q", "known_field", "expected"),
+    [
+        (
+            "metadata.creators.person_or_org.name: TestFirstName, TestLastName",
+            "creators",
+            "metadata.creators: TestFirstName, TestLastName",
+        ),
+        (
+            "metadata.rights.details: test_details and metadata.rights.test_field: test_value",
+            "rights",
+            "metadata.rights: test_details and metadata.rights: test_value",
+        ),
+        (
+            "+metadata.title.details: test_details -metadata.title.test_field1: test_value",
+            "title",
+            "+metadata.title: test_details -metadata.title: test_value",
+        ),
+    ],
+)
+def test_diff_element_description_match_key(  # noqa: D103
+    full_q: str,
+    known_field: str,
+    expected: str,
+) -> None:
+    assert (  # noqa: S101
+        replace_query_params_with_known_schema(full_q, known_field) == expected
+    )


### PR DESCRIPTION
- override search service method to change query params in order to respect the global-search schema

before:
<img width="2430" height="1326" alt="image" src="https://github.com/user-attachments/assets/32970d2b-1f74-493e-99fc-a89ecbbfafe7" />

after: 
<img width="2430" height="1326" alt="image" src="https://github.com/user-attachments/assets/aaf993fb-3882-4f35-9580-67ec9b53e0d8" />

addresses this issue: https://github.com/tugraz-rdm/institutional-services-board/issues/56
