### PR TITLE
Add Global Search navigation template config hook

### DIFF
--- a/invenio_records_global_search/config.py
+++ b/invenio_records_global_search/config.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023-2025 Graz University of Technology.
+# Copyright (C) 2023-2026 Graz University of Technology.
 #
 # invenio-records-global-search is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -78,6 +78,13 @@ GLOBAL_SEARCH_SEARCH = {
 }
 
 GLOBAL_SEARCH_BASE_TEMPLATE = "invenio_records_global_search/base.html"
+
+GLOBAL_SEARCH_NAV_TEMPLATE = None
+"""Template injected above the global search app.
+
+Set to a template path to render a custom nav above the search results
+e.g. a resource type switcher. ``None`` disables the injection.
+"""
 
 GLOBAL_SEARCH_ORIGINAL_SCHEMAS: dict[str, dict[str, str]] = {}
 """Configure the original schema names."""

--- a/invenio_records_global_search/records/models.py
+++ b/invenio_records_global_search/records/models.py
@@ -8,7 +8,6 @@
 
 """Dublin Core database models."""
 
-
 from invenio_db import db
 from invenio_records.models import RecordMetadataBase
 

--- a/invenio_records_global_search/records/systemfields/__init__.py
+++ b/invenio_records_global_search/records/systemfields/__init__.py
@@ -8,7 +8,6 @@
 
 """System Fields for Global Search records."""
 
-
 from .context import GlobalSearchPIDFieldContext
 from .original import OriginalField
 from .providers import GlobalSearchRecordProvider

--- a/invenio_records_global_search/resources/config.py
+++ b/invenio_records_global_search/resources/config.py
@@ -7,6 +7,7 @@
 # details.
 
 """Invenio Global Search Record Resource Config."""
+
 from typing import ClassVar
 
 from flask_resources import (

--- a/invenio_records_global_search/resources/serializers/serializer.py
+++ b/invenio_records_global_search/resources/serializers/serializer.py
@@ -8,7 +8,6 @@
 
 """Invenio Dublin Core Record Resource serializers."""
 
-
 from flask_resources import BaseListSchema, JSONSerializer
 from flask_resources.serializers import MarshmallowSerializer
 

--- a/invenio_records_global_search/services/components/__init__.py
+++ b/invenio_records_global_search/services/components/__init__.py
@@ -8,7 +8,6 @@
 
 """Components."""
 
-
 from invenio_records_resources.services.records.components import MetadataComponent
 
 from .original import OriginalComponent

--- a/invenio_records_global_search/services/permissions.py
+++ b/invenio_records_global_search/services/permissions.py
@@ -7,6 +7,7 @@
 # details.
 
 """Global Search permission policy."""
+
 from typing import ClassVar
 
 from invenio_records_permissions.generators import AnyUser, RecordOwners, SystemProcess

--- a/invenio_records_global_search/services/services.py
+++ b/invenio_records_global_search/services/services.py
@@ -7,6 +7,7 @@
 # details.
 
 """Global Search Services."""
+
 from typing import Any
 
 from flask import current_app

--- a/invenio_records_global_search/templates/invenio_records_global_search/search/search.html
+++ b/invenio_records_global_search/templates/invenio_records_global_search/search/search.html
@@ -1,10 +1,12 @@
 {#
-  Copyright (C) 2023 Graz University of Technology
+  Copyright (C) 2023-2026 Graz University of Technology
 
   invenio-records-global-search is free software; you can redistribute it and/or modify
   it under the terms of the MIT License; see LICENSE file for more details.
 #}
 {%- extends config.GLOBAL_SEARCH_BASE_TEMPLATE %}
+{%- set title = _("All Resources") %}
+{%- set page_description = _("Search and discover across all research results, publications, and educational resources.") %}
 
 {%- block javascript %}
 {{ super() }}
@@ -12,10 +14,11 @@
 {%- endblock %}
 
 {%- block page_body %}
-
 <div class="ui container">
+  {%- if config.get('GLOBAL_SEARCH_NAV_TEMPLATE') %}
+    {%- include config.GLOBAL_SEARCH_NAV_TEMPLATE %}
+  {%- endif %}
   <div id="invenio-search-global-search-config"
        data-invenio-search-config='{{ search_app_global_search_config() | tojson }}'></div>
 </div>
-
 {%- endblock page_body %}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023-2025 Graz University of Technology.
+# Copyright (C) 2023-2026 Graz University of Technology.
 #
 # invenio-records-global-search is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -40,8 +40,8 @@ install_requires =
 tests =
     invenio-app>=2.0.0
     invenio-search[opensearch2]>=3.0.0,<4.0.0
-    pytest-black-ng>=0.4.0
-    pytest-invenio>=2.1.0,<3.0.0
+    pytest-black>=0.6.0
+    pytest-invenio>=4.0.0,<5.0.0
     ruff>=0.0.263
     sphinx>=4.5.0
 


### PR DESCRIPTION
Adds Global Search navigation template to config.py and injects it above the search app in the search template